### PR TITLE
Feat/#2 admin request tab

### DIFF
--- a/src/components/DesktopTab.jsx
+++ b/src/components/DesktopTab.jsx
@@ -8,8 +8,8 @@ const StyledTabs = styled(Tabs)`
     border: none;
 
   .nav-link {
-    padding: 0;
-    width: 7rem;
+    width: auto;
+    padding: 1rem;
     color: ${(props) => props.theme.colors.gray50};
     background-color: transparent;
     border: none;

--- a/src/components/DesktopTab.jsx
+++ b/src/components/DesktopTab.jsx
@@ -6,7 +6,7 @@ import Tabs from 'react-bootstrap/Tabs';
 const StyledTabs = styled(Tabs)`
     width: 35rem;
     border: none;
-    
+
   .nav-link {
     padding: 0;
     width: 7rem;
@@ -21,33 +21,17 @@ const StyledTabs = styled(Tabs)`
       text-decoration: underline;
     }
   }
-  .tab-content {
-    border: none;
-    padding: 20px;
-  }
+
 `;
 
-export default function DesktopTab() {
+export default function DesktopTab({tabData}) {
     return (
-        <StyledTabs
-            defaultActiveKey="profile"
-            className="mb-3"
-        >
-            <Tab eventKey="전체 요청" title="전체 요청">
-                Tab content 전체 요청
-            </Tab>
-            <Tab eventKey="승인" title="승인">
-                Tab content for 승인
-            </Tab>
-            <Tab eventKey="보류" title="보류">
-                Tab content for 보류
-            </Tab>
-            <Tab eventKey="거절" title="거절">
-                Tab content for 거절
-            </Tab>
-            <Tab eventKey="미열람" title="미열람">
-                Tab content for 미열람
-            </Tab>
+        <StyledTabs defaultActiveKey={tabData[0]?.eventKey} className="mb-3">
+            {tabData.map((tab) => (
+                <Tab eventKey={tab.eventKey} title={tab.title} key={tab.eventKey}>
+                    {tab.content}
+                </Tab>
+            ))}
         </StyledTabs>
     );
 }

--- a/src/components/DesktopTab.jsx
+++ b/src/components/DesktopTab.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+
+const StyledTabs = styled(Tabs)`
+    width: 35rem;
+    border: none;
+    
+  .nav-link {
+    padding: 0;
+    width: 7rem;
+    color: ${(props) => props.theme.colors.gray50};
+    background-color: transparent;
+    border: none;
+    text-align:left;
+    &:hover,
+    &.active {
+      font-weight: 600;
+      color: ${(props) => props.theme.colors.black};
+      text-decoration: underline;
+    }
+  }
+  .tab-content {
+    border: none;
+    padding: 20px;
+  }
+`;
+
+export default function DesktopTab() {
+    return (
+        <StyledTabs
+            defaultActiveKey="profile"
+            className="mb-3"
+        >
+            <Tab eventKey="전체 요청" title="전체 요청">
+                Tab content 전체 요청
+            </Tab>
+            <Tab eventKey="승인" title="승인">
+                Tab content for 승인
+            </Tab>
+            <Tab eventKey="보류" title="보류">
+                Tab content for 보류
+            </Tab>
+            <Tab eventKey="거절" title="거절">
+                Tab content for 거절
+            </Tab>
+            <Tab eventKey="미열람" title="미열람">
+                Tab content for 미열람
+            </Tab>
+        </StyledTabs>
+    );
+}

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,5 +1,4 @@
 import React, {useRef} from 'react';
-import styled from 'styled-components';
 
 
 export default function SearchBar() {

--- a/src/pages/requestManage/RequestManage.jsx
+++ b/src/pages/requestManage/RequestManage.jsx
@@ -5,13 +5,25 @@ import Sidebar from '../../components/Sidebar';
 import DesktopTab from '../../components/DesktopTab';
 
 export default function RequestManage() {
+    const tabData = [
+        { eventKey: 'allRequests', title: '전체요청', content: '전체 요청 내용' },
+        { eventKey: 'approved', title: '승인', content: '승인된 요청 내용' },
+        { eventKey: 'pending', title: '보류', content: '보류된 요청 내용' },
+        { eventKey: 'rejected', title: '거절', content: '거절된 요청 내용' },
+        { eventKey: 'unread', title: '미열람', content: '미열람된 요청 내용' },
+    ];
+    const tabData2 = [
+        { eventKey: 'allRequests', title: '전체직원', content: '전체 직원' },
+        { eventKey: 'approved', title: '기자', content: '기자' },
+        { eventKey: 'pending', title: '일반기자', content: '일반기자' },
+    ];
     return (
         <div className="flex" style={{ width: "100vw" }}>
             <Sidebar />
             <div className="desktop-container">
                 <SearchBar />
                 <div style={{ height: '3rem' }}></div>
-                <DesktopTab/>
+                <DesktopTab tabData={tabData}/>
                 
             </div>
         </div>

--- a/src/pages/requestManage/RequestManage.jsx
+++ b/src/pages/requestManage/RequestManage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import SearchBar from '../../components/SearchBar';
 import Sidebar from '../../components/Sidebar';
+import DesktopTab from '../../components/DesktopTab';
 
 export default function RequestManage() {
     return (
@@ -9,6 +10,9 @@ export default function RequestManage() {
             <Sidebar />
             <div className="desktop-container">
                 <SearchBar />
+                <div style={{ height: '3rem' }}></div>
+                <DesktopTab/>
+                
             </div>
         </div>
     );

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -228,3 +228,18 @@
 .searchbar i{
     cursor: pointer;
 }
+.desktop-tabs{
+    display: flex;
+    width: 80%;
+}
+.desktop-tabs button{
+    width: 9rem;
+    padding: 0;
+    background-color: transparent;
+    color: var(--color-gray60);
+}
+.desktop-tabs button:hover{
+    background-color: transparent;
+    color: var(--color-black);
+    font-weight: 800;
+}

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -228,18 +228,3 @@
 .searchbar i{
     cursor: pointer;
 }
-.desktop-tabs{
-    display: flex;
-    width: 80%;
-}
-.desktop-tabs button{
-    width: 9rem;
-    padding: 0;
-    background-color: transparent;
-    color: var(--color-gray60);
-}
-.desktop-tabs button:hover{
-    background-color: transparent;
-    color: var(--color-black);
-    font-weight: 800;
-}


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [x]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 

> 좀 못생긴 것 같은데 어떠신가요,,,,

1.  bootstrap에서 제공하는 tab 사용
2. styled-component로 css오버라이딩 하여 커스텀함
3. prop에 tabData를 넣어서 tab 재활용 가능
```javascript
const tabData = [
        { eventKey: 'allRequests', title: '전체요청', content: '전체 요청 내용' },
        { eventKey: 'approved', title: '승인', content: '승인된 요청 내용' },
        { eventKey: 'pending', title: '보류', content: '보류된 요청 내용' },
        { eventKey: 'rejected', title: '거절', content: '거절된 요청 내용' },
        { eventKey: 'unread', title: '미열람', content: '미열람된 요청 내용' },
];
<DesktopTab tabData={tabData}/>
``` 


## ✅ 테스트 결과
1. 편집장 기사 관리 페이지 탭
![image](https://github.com/user-attachments/assets/a90e0c0c-ee90-4915-92af-dbb472c3b482)

2. tabData를 변경했을 때 (재활용)
![image](https://github.com/user-attachments/assets/47f272f4-cc0c-4114-b3ad-498d35bec7d4)



## 🔖 관련 이슈
### #2 [feat] 관리자
