### PR TITLE
feat: 카카오톡 공유 템플릿 생성

### DIFF
--- a/src/pages/articleDetail/ArticleContent.jsx
+++ b/src/pages/articleDetail/ArticleContent.jsx
@@ -128,7 +128,7 @@ const ArticleContent = () => {
                     ></i>
                     <small className='taCenter block'>{articleLikeCount}</small>
                 </div>
-                <KakaoShare ></KakaoShare>
+                <KakaoShare title={articleTitle} content={articleSubtit} link="articleDetail" THU="http://k.kakaocdn.net/dn/Q2iNx/btqgeRgV54P/VLdBs9cvyn8BJXB3o7N8UK/kakaolink40_original.png" />
             </div>
 
             <SubscriptionModal

--- a/src/utils/KakaoShare.jsx
+++ b/src/utils/KakaoShare.jsx
@@ -1,89 +1,36 @@
-// KakaoShare.jsx
 import { useEffect } from 'react';
 
-export default function KakaoShare() {
+export default function KakaoShare({ title, content, THU, link }) {
     useEffect(() => {
-        kakaoButton();
+        if (window.Kakao && !window.Kakao.isInitialized()) {
+            window.Kakao.init('7771b77e241269433b52a22a92528b7e'); // Kakao 초기화
+        }
     }, []);
 
     const kakaoButton = () => {
+        console.log('제목:', title);
+        console.log('설명:', content);
+        console.log('이미지 URL:', THU);
+        console.log('링크 URL:', link);
+
         if (window.Kakao) {
-            const kakao = window.Kakao;
-
-            if (!kakao.isInitialized()) {
-                kakao.init('7771b77e241269433b52a22a92528b7e');
-            }
-
-            kakao.Share.createDefaultButton({
-                container: '#kakaotalk-sharing-btn',
-                objectType: 'feed',
-                content: {
-                    title: '오늘의 디저트',
-                    description: '아메리카노, 빵, 케익',
-                    imageUrl:
-                        'https://mud-kage.kakao.com/dn/NTmhS/btqfEUdFAUf/FjKzkZsnoeE4o19klTOVI1/openlink_640x640s.jpg',
-                    link: {
-                        mobileWebUrl: 'https://developers.kakao.com',
-                        webUrl: 'https://developers.kakao.com',
-                    },
+            window.Kakao.Share.sendCustom({
+                templateId: 113405,
+                templateArgs: {
+                    title, link, content, THU
                 },
-                itemContent: {
-                    profileText: 'Kakao',
-                    profileImageUrl: 'https://mud-kage.kakao.com/dn/Q2iNx/btqgeRgV54P/VLdBs9cvyn8BJXB3o7N8UK/kakaolink40_original.png',
-                    titleImageUrl: 'https://mud-kage.kakao.com/dn/Q2iNx/btqgeRgV54P/VLdBs9cvyn8BJXB3o7N8UK/kakaolink40_original.png',
-                    titleImageText: 'Cheese cake',
-                    titleImageCategory: 'Cake',
-                    items: [
-                        {
-                            item: 'Cake1',
-                            itemOp: '1000원',
-                        },
-                        {
-                            item: 'Cake2',
-                            itemOp: '2000원',
-                        },
-                        {
-                            item: 'Cake3',
-                            itemOp: '3000원',
-                        },
-                        {
-                            item: 'Cake4',
-                            itemOp: '4000원',
-                        },
-                        {
-                            item: 'Cake5',
-                            itemOp: '5000원',
-                        },
-                    ],
-                    sum: 'Total',
-                    sumOp: '15000원',
-                },
-                social: {
-                    likeCount: 10,
-                    commentCount: 20,
-                    sharedCount: 30,
-                },
-                buttons: [
-                    {
-                        title: '웹으로 이동',
-                        link: {
-                            mobileWebUrl: 'https://developers.kakao.com',
-                            webUrl: 'https://developers.kakao.com',
-                        },
-                    },
-                    {
-                        title: '앱으로 이동',
-                        link: {
-                            mobileWebUrl: 'https://developers.kakao.com',
-                            webUrl: 'https://developers.kakao.com',
-                        },
-                    },
-                ],
             });
         }
     };
 
     return (
-        <button id='kakaotalk-sharing-btn' className='shareButton' style={{ marginLeft: "auto" }}>공유 &nbsp; <i className="bi bi-share" /></button>
+        <button 
+            id='kakaotalk-sharing-btn' 
+            className='shareButton' 
+            style={{ marginLeft: "auto" }} 
+            onClick={kakaoButton}
+        >
+            공유 &nbsp; <i className="bi bi-share" />
+        </button>
     );
 }


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1.   index.html에 카카오 API SDK 설정
### 2. utils에 카카오톡 공유 템플릿 등록
### 3. article Detail에 공유 버튼 연결

## ✅ 테스트 결과
### 1.   
<img width="492" alt="image" src="https://github.com/user-attachments/assets/cbe9a7a9-88e8-4873-9bdc-38b1ab59f4ca">

## ✏️ 추가 수정 사항
### 1. 대표 이미지 (THU) 연결(현재 카카오톡 제공 이미지)
### 2. 각 기사 링크(link) 연결(현재 localhost/articleDetail)

## 🔖 관련 이슈
### #4  [feat] 기사 상세 페이지
### #33 [feat] 카카오톡 공유하기