### PR TITLE
Feat/#101 login page add : 로그인 API 연동 및 헤더 / 드롭다운 상태 동적 변경 , 마이페이지 API 연동 

### DIFF
--- a/src/apis/axios.jsx
+++ b/src/apis/axios.jsx
@@ -5,6 +5,7 @@ const apiClient = axios.create({
     headers: {
         'Content-Type': 'application/json',
     },
+    withCredentials: true, 
 });
 
 // 요청 인터셉터 설정
@@ -33,6 +34,8 @@ const getRequest = (url, params = {}, headers = {}) => {
 const postRequest = (url, data, headers = {}) => {
   return apiClient.post(url, data, { headers });
 };
+
+//POST 요청 함수 + 
 
 // PUT 요청 함수
 const putRequest = (url, data, headers = {}) => {

--- a/src/apis/axios.jsx
+++ b/src/apis/axios.jsx
@@ -5,7 +5,6 @@ const apiClient = axios.create({
     headers: {
         'Content-Type': 'application/json',
     },
-    withCredentials: true, 
 });
 
 // 요청 인터셉터 설정

--- a/src/components/DropDown.jsx
+++ b/src/components/DropDown.jsx
@@ -2,11 +2,43 @@ import styled from "styled-components";
 import Dropdown from 'react-bootstrap/Dropdown';
 import DropdownButton from 'react-bootstrap/DropdownButton';
 import { useNavigate } from 'react-router-dom';
-
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 
 function MyDropdown() {
     const navigate = useNavigate();
-    const isJournalist = false; //일단 백엔드 연결 전이라 일반회원 페이지 연결 되도록 했습니다
+    const [isJournalist, setIsJournalist] = useState(false);  // 회원 유형을 상태로 관리
+
+    const checkUserType = async () => {
+        const accessToken = sessionStorage.getItem('authToken');  // sessionStorage에서 토큰을 가져옴
+        if (!accessToken) {
+            console.error('No access token found');
+            return;  // 토큰이 없으면 API 호출을 하지 않음
+        }
+        try {
+            const response = await axios.get('/api/user/checkUserType', {
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`  // 가져온 토큰을 사용
+                }
+            });
+    
+            const userType = response.data;
+    
+            if (userType === 'GENERAL_MEMBER') {
+                setIsJournalist(false);
+            } else {
+                setIsJournalist(true);
+            }
+        } catch (error) {
+            console.error("회원 유형 확인 실패", error);
+        }
+    };
+
+    // 컴포넌트가 마운트 될 때 API 호출
+    useEffect(() => {
+        checkUserType();
+    }, []);
+    
 
     const handleAccountClick = () => {
         if (isJournalist) {
@@ -21,8 +53,13 @@ function MyDropdown() {
             <Dropdown.Item onClick={handleAccountClick}>계정</Dropdown.Item>
             <Dropdown.Item href="../mobileNoti">알림</Dropdown.Item>
             <Dropdown.Item href="../log">내 활동</Dropdown.Item>
-            <Dropdown.Item href="../articleWrite">기사 작성</Dropdown.Item>
-            <Dropdown.Item href="../myArticle">작성한 기사</Dropdown.Item>
+            {/* 기자일 때만 보여지는 메뉴 */}
+            {isJournalist && (
+                <>
+                    <Dropdown.Item href="../articleWrite">기사 작성</Dropdown.Item>
+                    <Dropdown.Item href="../myArticle">작성한 기사</Dropdown.Item>
+                </>
+            )}
         </CustomDropdown>
     );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import MyDropdown from './DropDown';
 
@@ -20,6 +20,19 @@ const Header = () => {
     const today = new Date();  // Date 객체 생성 
     const navigate = useNavigate();
 
+    //로그인 상태 관리 
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+    // 로그인 상태 확인 함수
+    const checkLoginStatus = () => {
+        const authToken = sessionStorage.getItem('authToken');
+        setIsLoggedIn(!!authToken);
+    };
+
+    useEffect(() => {
+        checkLoginStatus();  // 컴포넌트가 마운트될 때 로그인 상태 확인
+    }, []);
+
     const handleLogoClick = () => {
         navigate('/main'); // /main으로 이동
     };
@@ -36,6 +49,12 @@ const Header = () => {
     const handleSignupClick = (e) => {
         e.preventDefault();
         navigate('/signup');
+    };
+
+    const handleLogoutClick = () => {
+        sessionStorage.removeItem('authToken');  // authToken 삭제로 로그아웃 처리
+        setIsLoggedIn(false);  // 로그인 상태를 false로 변경
+        navigate('/main');  // 로그아웃 후 메인 페이지로 리디렉션
     };
 
     return (
@@ -56,10 +75,18 @@ const Header = () => {
                         <MyDropdown />
                     </div>
                     <div className='flex aiCenter'>
-                        <div className='link'>
-                            <a href='#' onClick={handleLoginClick} style={{ cursor: 'pointer' }}>로그인</a>
-                            <span> &nbsp;&nbsp;|&nbsp;&nbsp; </span>
-                            <a href='#' onClick={handleSignupClick} style={{ cursor: 'pointer' }}>회원가입</a>
+                    <div className='link'>
+                            {isLoggedIn ? (
+                                // 로그인된 상태일 때 '로그아웃' 버튼 표시
+                                <a href='#' onClick={handleLogoutClick} style={{ cursor: 'pointer' }}>로그아웃</a>
+                            ) : (
+                                // 로그인 안된 상태일 때 '로그인'과 '회원가입' 버튼 표시
+                                <>
+                                    <a href='#' onClick={handleLoginClick} style={{ cursor: 'pointer' }}>로그인</a>
+                                    <span> &nbsp;&nbsp;|&nbsp;&nbsp; </span>
+                                    <a href='#' onClick={handleSignupClick} style={{ cursor: 'pointer' }}>회원가입</a>
+                                </>
+                            )}
                         </div>
                     </div>
                 </div>

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -33,7 +33,6 @@ export default function Login() {
 
     const handleLogin = (e) => {
         e.preventDefault();
-        // 로그인 처리 로직
 
         const data={
             email: email,
@@ -44,6 +43,8 @@ export default function Login() {
                 console.log(response.data);
                 sessionStorage.setItem('authToken', response.data.accessToken);
                 console.log('저장된 authToken:', sessionStorage.getItem('authToken'));
+            
+                navigate('/main')
             })
             .catch(error => {
                 console.error('Error fetching subscriptions:', error);

--- a/src/pages/mypage/GeneralMyPage.jsx
+++ b/src/pages/mypage/GeneralMyPage.jsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';  // useState 임포트 확인
+import React, { useState, useEffect } from 'react'; 
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import axios from 'axios';
 
 import profileIcon  from '../../assets/profileDefault.png'; 
 
@@ -126,14 +127,50 @@ const NextButton = styled.button`
 
 export default function GeneralMyPage() {
     const navigate = useNavigate(); 
+    const [userData, setUserData] = useState({
+        nickname: '',
+        bio: '',
+        name: '',
+        email: '',
+        phoneNumber: '',
+        gender: '',
+    });
+
+    // 회원 정보 가져오는 함수
+    const getUserData = async () => {
+        try {
+            const response = await axios.get('/api/user/myPage', {
+                headers: {
+                    'Authorization': `Bearer ${sessionStorage.getItem('authToken')}`
+                }
+            });
+
+              // API 응답 받은 데이터로 상태 업데이트
+              setUserData({
+                nickname: response.data.nickname,
+                bio: response.data.bio,
+                name: response.data.name,
+                email: response.data.email,
+                phoneNumber: response.data.cp, 
+                gender: response.data.sex, 
+            });
+        } catch (error) {
+            console.error("회원 정보 불러오기 실패", error);
+        }
+    };
+
+    useEffect(() => {
+        getUserData();
+    }, []);
 
     const handleEditInfo = () => {
         navigate('/myPageGeneral/edit');
     };
 
     const handleLogout = () => {
+        sessionStorage.removeItem('authToken');
         alert('로그아웃되었습니다.');
-        navigate('/login');
+        navigate('/main');
     };
 
     const handleDeleteAccount = () => {
@@ -152,12 +189,12 @@ export default function GeneralMyPage() {
                 </ProfileImage>
                 <ProfileTextWrapper>
                     <NameWrapper>
-                        <NameText>닉네임</NameText>
-                        <EditSpace></EditSpace>
+                    <NameText>{userData.nickname || '익명'}</NameText>
+                    <EditSpace></EditSpace>
                     </NameWrapper>
                     <BioWrapper>
                         <VerticalLine></VerticalLine>
-                        <BioText>자기소개가 오는 자리입니다. 최대 25자입니다.</BioText>
+                        <BioText>{userData.bio || '자기소개는 아직 없어요. 추가해보세요!'}</BioText>
                         <EditSpace></EditSpace>
                     </BioWrapper>
                 </ProfileTextWrapper>
@@ -166,17 +203,17 @@ export default function GeneralMyPage() {
             <InfoWrapper>
                 <InfoColumn>
                     <InfoLabel>이름</InfoLabel>
-                    <InfoText>홍길동</InfoText>
+                    <InfoText>{userData.name }</InfoText>
                     <EditSpace></EditSpace>
                 </InfoColumn>
                 <InfoColumn>
                     <InfoLabel>이메일</InfoLabel>
-                    <InfoText>hong12@gmail.com</InfoText>
+                    <InfoText>{userData.email }</InfoText>
                     <EditSpace></EditSpace>
                 </InfoColumn>
                 <InfoColumn>
                     <InfoLabel>휴대폰 번호</InfoLabel>
-                    <InfoText>000-1111-2222</InfoText>
+                    <InfoText>{userData.phoneNumber}</InfoText>
                     <EditSpace></EditSpace>
                 </InfoColumn>
                 <InfoColumn>
@@ -186,7 +223,7 @@ export default function GeneralMyPage() {
                 </InfoColumn>
                 <InfoColumn>
                     <InfoLabel>성별</InfoLabel>
-                    <InfoText>남성</InfoText>
+                    <InfoText>{userData.gender}</InfoText>
                     <EditSpace></EditSpace>
                 </InfoColumn>
             </InfoWrapper>

--- a/src/pages/mypage/JournalistMyPage.jsx
+++ b/src/pages/mypage/JournalistMyPage.jsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';  // useState 임포트 확인
+import React, { useState, useEffect } from 'react';  // useState 임포트 확인
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-
+import axios from 'axios';
 import profileIcon  from '../../assets/profileDefault.png'; 
-import profileResetIcon from '../../assets/x-square.svg'; 
 
 
 const ProfileWrapper = styled.div`
@@ -126,14 +125,50 @@ const NextButton = styled.button`
 
 export default function JournalistMyPage() {
     const navigate = useNavigate(); 
+    const [userData, setUserData] = useState({
+        name: '',
+        bio: '',
+        publisher:'',
+        email: '',
+        phoneNumber: '',
+        gender: '',
+    });
+
+    // 회원 정보 가져오는 함수
+    const getUserData = async () => {
+        try {
+            const response = await axios.get('/api/user/myPage', {
+                headers: {
+                    'Authorization': `Bearer ${sessionStorage.getItem('authToken')}`
+                }
+            });
+
+              // API 응답 받은 데이터로 상태 업데이트
+              setUserData({
+                name: response.data.name,
+                bio: response.data.bio,
+                publisher: response.data.publisher,
+                email: response.data.email,
+                phoneNumber: response.data.cp, 
+                gender: response.data.sex, 
+            });
+        } catch (error) {
+            console.error("회원 정보 불러오기 실패", error);
+        }
+    };
+
+    useEffect(() => {
+        getUserData();
+    }, []);
 
     const handleEditInfo = () => {
         navigate('/myPageJournalist/edit');
     };
 
     const handleLogout = () => {
+        sessionStorage.removeItem('authToken');
         alert('로그아웃되었습니다.');
-        navigate('/login');
+        navigate('/main');
     };
 
     const handleDeleteAccount = () => {
@@ -152,12 +187,12 @@ export default function JournalistMyPage() {
                 </ProfileImage>
                 <ProfileTextWrapper>
                     <NameWrapper>
-                        <NameText>홍기자</NameText>
+                    <NameText>{userData.name}</NameText>
                         <EditSpace></EditSpace>
                     </NameWrapper>
                     <BioWrapper>
                         <VerticalLine></VerticalLine>
-                        <BioText>자기소개가 오는 자리입니다. 최대 25자입니다.</BioText>
+                        <BioText>{userData.bio || '자기소개는 아직 없어요. 추가해보세요!'}</BioText>
                         <EditSpace></EditSpace>
                     </BioWrapper>
                 </ProfileTextWrapper>
@@ -166,17 +201,17 @@ export default function JournalistMyPage() {
             <InfoWrapper>
                 <InfoColumn>
                     <InfoLabel>소속</InfoLabel>
-                    <InfoText>00일보</InfoText>
+                    <InfoText>{userData.publisher }</InfoText>
                     <EditSpace></EditSpace>
                 </InfoColumn>
                 <InfoColumn>
                     <InfoLabel>이메일</InfoLabel>
-                    <InfoText>hong12@gmail.com</InfoText>
+                    <InfoText>{userData.email }</InfoText>
                     <EditSpace></EditSpace>
                 </InfoColumn>
                 <InfoColumn>
                     <InfoLabel>휴대폰 번호</InfoLabel>
-                    <InfoText>000-1111-2222</InfoText>
+                    <InfoText>{userData.phoneNumber}</InfoText>
                     <EditSpace></EditSpace>
                 </InfoColumn>
                 <InfoColumn>
@@ -187,7 +222,7 @@ export default function JournalistMyPage() {
                 
                 <InfoColumn>
                     <InfoLabel>성별</InfoLabel>
-                    <InfoText>남성</InfoText>
+                    <InfoText>{userData.gender}</InfoText>
                     <EditSpace></EditSpace>
                 </InfoColumn>
             </InfoWrapper>


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1.   로그인 API 연동
### 2.  로그인 후 헤더 상태 변경 
### 3. 로그인 후 드롭다운 상태 변경 
### 4. 마이페이지 API 연동 
### 5. 헤더 및 마이페이지에서의 로그아웃 처리 

## ✅ 테스트 결과
### 1.   로그인 후 헤더 상태 
<img width="452" alt="image" src="https://github.com/user-attachments/assets/44258f21-6c74-4c0f-b201-33368efdd769">

### 2. 일반회원 로그인 후 드롭 다운 상태 (기사 작성 버튼 제거)
<img width="161" alt="image" src="https://github.com/user-attachments/assets/7d1b926b-517b-40f9-9afc-de4990e822b3">


### 3. 기자 로그인 후 드롭 다운 상태 (기사 작성 관련 버튼 생성)
<img width="160" alt="image" src="https://github.com/user-attachments/assets/79e5383d-e04a-413c-9892-5d606825aa9b">


###4. 일반 회원 로그인 후 마이페이지(드롭다운-계정)
<img width="442" alt="image" src="https://github.com/user-attachments/assets/fb6ff695-bb3e-4e86-b886-b8f0fe36af0d">


### 5. 기자 로그인 후 마이페이지 (드롭다운-계정) 
| 소속이 안뜨는 이유는 아직 편집장이 요청을 수락 안해서 그런것 같습니다 

<img width="455" alt="image" src="https://github.com/user-attachments/assets/5b33d10b-4635-47a3-8ac3-c9935409cd44">

## 🔖 관련 이슈
### #101 
