### PR TITLE
Feat/#152 token add: 만료된 토큰 재발급 API 연결 및 헤더 수정 

### DIFF
--- a/src/apis/noCTAxios.jsx
+++ b/src/apis/noCTAxios.jsx
@@ -22,13 +22,27 @@ noContentTypeApiClient.interceptors.response.use(
     async (error) => {
         const originalRequest = error.config;
 
+        // 401 에러 처리
         if (error.response?.status === 401 && !originalRequest._retry) {
+            const errorCode = error.response?.data?.code;
+
             originalRequest._retry = true;
+
             console.log('토큰 갱신 로직 실행');
-            const newAccessToken = await reissueToken();
-            originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-            console.log('토큰 갱신 완료! API를 다시 호출합니다');
-            return noContentTypeApiClient(originalRequest);
+            try {
+                const newAccessToken = await reissueToken();
+                if (newAccessToken) {
+                    originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+                    console.log('토큰 갱신 완료! API를 다시 호출합니다.');
+                    return apiClient(originalRequest);
+                } 
+            } catch (e) {
+                console.error('토큰 갱신 중 오류 발생:', e);
+                if (e.response?.data?.code === 'TOKEN_003') {
+                console.error('리프레시 토큰이 만료되었습니다. 로그인 창으로 이동');
+                redirectToLogin(); 
+                }
+            }
         }
 
         return Promise.reject(error);

--- a/src/apis/util/tokenUtils.jsx
+++ b/src/apis/util/tokenUtils.jsx
@@ -1,0 +1,47 @@
+import axios from 'axios';
+
+let isRefreshing = false;
+let refreshSubscribers = [];
+
+export const subscribeTokenRefresh = (cb) => {
+    refreshSubscribers.push(cb);
+};
+
+export const onRefreshed = (newAccessToken) => {
+    refreshSubscribers.forEach((cb) => cb(newAccessToken));
+    refreshSubscribers = [];
+};
+
+export const reissueToken = async () => {
+    if (!isRefreshing) {
+        isRefreshing = true;
+
+        try {
+            const refreshToken = sessionStorage.getItem('refreshToken');
+            const response = await axios.post(
+                `${import.meta.env.VITE_API_URL}/api/token/reissue`,
+                refreshToken ,
+                {
+                    headers: {
+                        'Content-Type': 'text/plain',
+                    },
+                }
+            );
+
+            const newAccessToken = response.data.accessToken;
+            const newRefreshToken = response.data.refreshToken; 
+            sessionStorage.setItem('authToken', newAccessToken);
+            sessionStorage.setItem('refreshToken',newRefreshToken);
+            isRefreshing = false;
+            onRefreshed(newAccessToken);
+            return newAccessToken;
+        } catch (error) {
+            console.error('리프레시 토큰 요청 실패:', error);
+            isRefreshing = false;
+            throw error;
+        }
+    }
+    return new Promise((resolve) => {
+        subscribeTokenRefresh(resolve);
+    });
+};

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -72,8 +72,8 @@ const Header = () => {
                             onClick={handleSearchClick}
                             >
                         </i>
-                        <MyDropdown />
-                    </div>
+                        {isLoggedIn && <MyDropdown />}
+                        </div>
                     <div className='link'>
                         {isLoggedIn ? (
                             // 로그인된 상태일 때 '로그아웃' 버튼 표시

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -40,17 +40,15 @@ export default function Login() {
         }
         postRequest('/api/user/login', data)
             .then(response => {
-                console.log(response.data);
                 sessionStorage.setItem('authToken', response.data.accessToken);
-                console.log('저장된 authToken:', sessionStorage.getItem('authToken'));
-            
+                sessionStorage.setItem('refreshToken', response.data.refreshToken);
+
+                console.log('token 정보 저장 완료!');
                 navigate('/main')
             })
             .catch(error => {
                 console.error('Error fetching subscriptions:', error);
             });
-
-        console.log('Logging in with:', { email, password });
     };
 
     return (


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
### 1.  만료된 토큰 재발급 API 연결 
> axsios.jsx와 noCTAxsios.jsx의 API응답에서 토큰 만료 오류 발생시(401) 토큰 재발급하는 API 사용하여 세션 유지하도록 함 
### 2.  세션 종료 시 로그인 창으로 유도하는 로직 추가 
> refreshToken도 만료되었을 경우, 로그인창으로 유도 
### 3. 로그인 유무에 따른 헤더의 메뉴 버튼 활성화 설정 

## ✅ 테스트 결과
### 1.   토큰 재발급 테스트
|토큰 재발급|세션 종료시|
|-|-|
|![image](https://github.com/user-attachments/assets/8850804a-211f-4da5-8961-21617dd1ec32)|![image](https://github.com/user-attachments/assets/c76588e5-cb3d-4955-9b0e-e7b3f438ddbb)|

### 2.  로그인 유무에 따른 헤더의 메뉴 버튼 활성화 테스트  
|로그인 전(메뉴버튼 비활성화)|로그인 후(메뉴버튼 활성화)|
|-|-|
|![image](https://github.com/user-attachments/assets/b7c025e1-c532-4248-8193-764ac37b08e5)|![image](https://github.com/user-attachments/assets/dabe8acc-7e86-4c9d-9b5d-9497ef27abc8)|

## 🔖 관련 이슈
### #152
